### PR TITLE
Package rename breaks dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ examples = Extension('examples',
 supercollider = Extension('apicultor.supercollider',
                     sources = ['live_coding.sc', 'setup_performance.sc'])
 
-setup(name='apicultor-dev',
+setup(name='apicultor',
       version='2.0.1',
       url='https://www.github.com/MarsCrop/apicultor',
       description='BigData system of sound effects, remixes and sound collections',


### PR DESCRIPTION
By renaming the package to "apicultor-dev", projects that depend on this package will break.
Please rename it back to "apicultor".